### PR TITLE
Fix C++ builds/tests and Python unit tests when run with Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The code for specific robots is in a directory starting with either the letter "
 We use [bazel](https://bazel.io) to build our code. You must be running linux to use bazel. A typical bazel build command would look like this:
 
 ```
-bazel build //o2016 --cpu=roborio
+bazel build //o2016:frc1678 --cpu=roborio
 ```
 
 You should also test anything that you change:

--- a/c2017/lemonscript/lemonscript.cpp
+++ b/c2017/lemonscript/lemonscript.cpp
@@ -58,33 +58,33 @@ void Lemonscript::UpdateAutoRoutine() {
   auto_list = c2017::QueueManager::GetInstance()->auto_list_;
   std::string filename = "none.auto";
   if (message) {
-    if (message.value()->auto_mode() == auto_list[0]) {
+    if (message.value()->auto_modes() == auto_list[0]) {
       filename = "none.auto";
-    } else if (message.value()->auto_mode() == auto_list[1]) {
+    } else if (message.value()->auto_modes() == auto_list[1]) {
       filename = "blue_hella_kpa.auto";
-    } else if (message.value()->auto_mode() == auto_list[2]) {
+    } else if (message.value()->auto_modes() == auto_list[2]) {
       filename = "blue_hella_kpa_new.auto";
-    } else if (message.value()->auto_mode() == auto_list[3]) {
+    } else if (message.value()->auto_modes() == auto_list[3]) {
       filename = "blue_hella_kpa_plus_gear.auto";
-    } else if (message.value()->auto_mode() == auto_list[4]) {
+    } else if (message.value()->auto_modes() == auto_list[4]) {
       filename = "blue_center_peg_plus_kpa.auto";
-    } else if (message.value()->auto_mode() == auto_list[5]) {
+    } else if (message.value()->auto_modes() == auto_list[5]) {
       filename = "blue_center_peg_plus_kpa_and_drive.auto";
-    } else if (message.value()->auto_mode() == auto_list[6]) {
+    } else if (message.value()->auto_modes() == auto_list[6]) {
       filename = "blue_far_peg_plus_kpa_and_drive.auto";
-    } else if (message.value()->auto_mode() == auto_list[7]) {
+    } else if (message.value()->auto_modes() == auto_list[7]) {
       filename = "red_hella_kpa.auto";
-    } else if (message.value()->auto_mode() == auto_list[8]) {
+    } else if (message.value()->auto_modes() == auto_list[8]) {
       filename = "red_hella_kpa_new.auto";
-    } else if (message.value()->auto_mode() == auto_list[9]) {
+    } else if (message.value()->auto_modes() == auto_list[9]) {
       filename = "red_hella_kpa_plus_gear.auto";
-    } else if (message.value()->auto_mode() == auto_list[10]) {
+    } else if (message.value()->auto_modes() == auto_list[10]) {
       filename = "red_center_peg_plus_kpa.auto";
-    } else if (message.value()->auto_mode() == auto_list[11]) {
+    } else if (message.value()->auto_modes() == auto_list[11]) {
       filename = "red_center_peg_plus_kpa_and_drive.auto";
-    } else if (message.value()->auto_mode() == auto_list[12]) {
+    } else if (message.value()->auto_modes() == auto_list[12]) {
       filename = "red_far_peg_plus_kpa_and_drive.auto";
-    } else if (message.value()->auto_mode() == auto_list[13]) {
+    } else if (message.value()->auto_modes() == auto_list[13]) {
       filename = "two_gear.auto";
     } else {
       filename = "none.auto";

--- a/c2017/subsystems/lights/lights.cpp
+++ b/c2017/subsystems/lights/lights.cpp
@@ -30,33 +30,33 @@ void Lights::Update() {
     light_color_ = LightColor::BLUE;
   } else if (calibrated_ && auto_running_) {
     if (auto_selection_queue) {
-      if (auto_selection_queue.value()->auto_mode() == auto_list[0]) {
+      if (auto_selection_queue.value()->auto_modes() == auto_list[0]) {
         light_color_ = LightColor::PINK;
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[1]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[1]) {
         light_color_ = FlashLights(LightColor::BLUE, LightColor::PINK, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[2]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[2]) {
         light_color_ = FlashLights(LightColor::TEAL, LightColor::WHITE, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[3]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[3]) {
         light_color_ = FlashLights(LightColor::BLUE, LightColor::TEAL, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[4]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[4]) {
         light_color_ = FlashLights(LightColor::BLUE, LightColor::GREEN, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[5]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[5]) {
         light_color_ = FlashLights(LightColor::BLUE, LightColor::YELLOW, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[6]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[6]) {
         light_color_ = FlashLights(LightColor::BLUE, LightColor::WHITE, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[7]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[7]) {
         light_color_ = FlashLights(LightColor::RED, LightColor::PINK, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[8]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[8]) {
         light_color_ = FlashLights(LightColor::PINK, LightColor::WHITE, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[9]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[9]) {
         light_color_ = FlashLights(LightColor::RED, LightColor::TEAL, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[10]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[10]) {
         light_color_ = FlashLights(LightColor::RED, LightColor::GREEN, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[11]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[11]) {
         light_color_ = FlashLights(LightColor::RED, LightColor::YELLOW, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[12]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[12]) {
         light_color_ = FlashLights(LightColor::RED, LightColor::WHITE, false);
-      } else if (auto_selection_queue.value()->auto_mode() == auto_list[13]) {
+      } else if (auto_selection_queue.value()->auto_modes() == auto_list[13]) {
         light_color_ = LightColor::WHITE;
       } else {
         light_color_ = FlashLights(LightColor::OFF, LightColor::PINK, false);

--- a/muan/logging/logger_test.cpp
+++ b/muan/logging/logger_test.cpp
@@ -151,7 +151,7 @@ TEST(Logger, TextLogger) {
   EXPECT_EQ(static_cast<MockFileWriter*>(logger.writer_.get())
                 ->mock_files["name.log"]
                 .str(),
-            "[DEBUG]1000:muan/logging/logger_test.cpp:147: test\n");
+            "[DEBUG]1000:muan/logging/logger_test.cpp:148: test\n");
 }
 
 }  // namespace logging

--- a/muan/proto/stack_proto.h
+++ b/muan/proto/stack_proto.h
@@ -137,7 +137,7 @@ auto WriteTimestamp(T* message)
       std::chrono::duration_cast<std::chrono::milliseconds>(
           aos::monotonic_clock::now() - aos::monotonic_clock::epoch())
           .count() -
-      (aos::time::UsingMockTime() ? 0 : start_time.load()));
+      (aos::time::UsingMockTime() ? start_time.load() : 0));
 }
 
 // This secondary WriteTimestamp function makes it work if the message getting
@@ -149,7 +149,7 @@ auto WriteTimestamp(T* message) -> decltype(message->set_timestamp(0), void()) {
       std::chrono::duration_cast<std::chrono::milliseconds>(
           aos::monotonic_clock::now() - aos::monotonic_clock::epoch())
           .count() -
-      (aos::time::UsingMockTime() ? 0 : start_time.load()));
+      (aos::time::UsingMockTime() ? start_time.load() : 0));
 }
 
 }  // namespace proto

--- a/third_party/frc971/control_loops/python/polytope.py
+++ b/third_party/frc971/control_loops/python/polytope.py
@@ -21,7 +21,7 @@ def _PiecewiseConcat(*args):
 
   Given ['a', 's'] and ['d', 'f'], returns ['ad', 'sf']
   """
-  return map(''.join, zip(*args))
+  return list(map(''.join, zip(*args)))
 
 
 def _SplitAndPad(s):
@@ -217,7 +217,7 @@ class HPolytope(object):
     """Builds an array of strings with the comparison in it for printing."""
     cmp_strings = []
     for index in range(height):
-      if index == (height - 1) / 2:
+      if index == math.floor((height - 1) / 2):
         cmp_strings.append("<= ")
       else:
         cmp_strings.append("   ")


### PR DESCRIPTION
The Python tests still pass with Python 2 though. Maybe the fixes to 971's
polytope.py would best be done upstream.